### PR TITLE
Set default value to false

### DIFF
--- a/collective/autopublishing/behavior.py
+++ b/collective/autopublishing/behavior.py
@@ -17,4 +17,4 @@ class IAutoPublishing(model.Schema):
     enableAutopublishing = schema.Bool(
         title=_(u'enableAutopublishing', default=u"Enable autopublishing?"),
         required=False,
-        default=True)
+        default=False)

--- a/collective/autopublishing/tests/test_autopublishing.txt
+++ b/collective/autopublishing/tests/test_autopublishing.txt
@@ -64,15 +64,20 @@ Let's create some objects for our tests::
     >>> portal.invokeFactory(id='news1', type_name='News Item', title='News 1')
     'news1'
 
-First here is what we have. Our objects have their enableAutopublishing set to true and their review state set to private::
+First here is what we have. Our objects have their enableAutopublishing set to false and their review state set to private::
 
     >>> wf = portal.portal_workflow
 
     >>> portal['document1'].enableAutopublishing, wf.getInfoFor(portal['document1'], 'review_state')
-    (True, 'private')
+    (False, 'private')
 
     >>> portal['news1'].enableAutopublishing, wf.getInfoFor(portal['news1'], 'review_state')
-    (True, 'private')
+    (False, 'private')
+
+Set enableAutopublishing of our objects to true::
+    
+    >>> portal['document1'].enableAutopublishing = True
+    >>> portal['news1'].enableAutopublishing = True
 
 Set their review state to pending.
 


### PR DESCRIPTION
Prevent automatic publishing of created objects.

If a new object was created and no publishing date was selected, the object was published automatically. 
